### PR TITLE
transparent-mods-auth: Ensure that all the "GET"-variables in the

### DIFF
--- a/templates/transparent-mods-auth/login.php
+++ b/templates/transparent-mods-auth/login.php
@@ -24,9 +24,20 @@ else
 }
 
 
+# If all ok, redirect to the "original" URL, after appending the original "GET"-variables.
+$original_url = $original_url . "?";
 
-# If all ok, redirect to the "original" URL.
-header('Location: ' . $original_url . '?check=0');
+foreach ($_GET as $key => $val)
+{
+        # Do not re-append "url" GET-variable.
+        if ($key == "url")
+        {
+                continue;
+        }
+
+        $original_url = $original_url . "$key=$val&";
+}
+
+header('Location: ' . $original_url . 'check=0');
 
 ?>
-


### PR DESCRIPTION
original URL, are re-added, after the authentication is confirmed via
this module.

Without this, things would break (for eg, until now, all internal-links
on Moodle were broken). With this patch applied, things will be back to
normal.
