### PR TITLE
Issues 4043: (sugar-stats) fix statistics consolidation install bug

### DIFF
--- a/roles/sugar-stats/tasks/statistics-consolidation.yml
+++ b/roles/sugar-stats/tasks/statistics-consolidation.yml
@@ -19,7 +19,7 @@
       regexp="^host\s+statsconso"
       line="host     statsconso     statsconso     samehost     md5"
       state=present
-      insertbefore="^host\s+all"
+      insertafter="^# IPv4 local connections"
       owner=postgres
       group=postgres
 


### PR DESCRIPTION
Two changes:
- change where to add psql user configuration to be just at the beginning of IPv4 section
- change source statistics-consolidation from git.sugarlabs.org to github.com

Issue: https://sugardextrose.org/issues/4043
