### PR TITLE
Issue 4640: (wondershaper) install ajenti plugin using just pip

### DIFF
--- a/roles/wondershaper/tasks/ajenti-wondershaper.yml
+++ b/roles/wondershaper/tasks/ajenti-wondershaper.yml
@@ -1,5 +1,5 @@
 - name: install wondershaper ajenti plugin
-  pip: https://github.com/migonzalvar/ajenti-plugin-wondershaper/archive/0.3.tar.gz
+  pip: name=https://github.com/migonzalvar/ajenti-plugin-wondershaper/archive/0.3.tar.gz
 
 - name: restart ajenti service
   service: name=ajenti


### PR DESCRIPTION
The ajenti plugin installation script (setup.py) copy the required files into /var/lib/ajenti/plugins/wondershaper.

See related source code https://github.com/migonzalvar/ajenti-plugin-wondershaper/compare/0.1.0...0.3

Issue: https://sugardextrose.org/issues/4640
