### PR TITLE
Issues #4722: (ajenti) use a generic regexp to match any port

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -20,7 +20,9 @@
 
 - name: change default port
   lineinfile: dest=/etc/ajenti/config.json
-              regexp=' 8000'
+              state=present
+              backrefs=yes
+              regexp='"port":\s*[0-9]{1,5}'
               line='"port":9990'
 
 - name: exe permission to ajenti


### PR DESCRIPTION
/etc/ajenti/config.json was corrupted when Ansible playbooks were run more than once because the previous regexp did not match so a new line was added.

Related to https://sugardextrose.org/issues/4722
