### PR TITLE
httpd: prevent home dir creation for user apache

### DIFF
--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -48,6 +48,7 @@
   user: name=apache
         groups=admin
         state=present
+        createhome=no
 
 - name: Enable httpd
   service: name=httpd


### PR DESCRIPTION
The default value for _createhome_ is `yes`. New version of ansible introduce a bug that make this task fail. As `apache` user doesn't need the home dir, I've just removed the option.
