### PR TITLE
 Remove ajenti tracebacks and improve performance

### DIFF
--- a/roles/ajenti/tasks/main.yml
+++ b/roles/ajenti/tasks/main.yml
@@ -13,7 +13,7 @@
     - pkg: gcc
 
 - name: install ajenti from Pypi
-  pip: name=ajenti version=0.99.34
+  pip: name=https://github.com/migonzalvar/ajenti/releases/download/0.99.34-patched3/ajenti-0.99.34-patched3.tar.gz
 
 - name: install python-catcher
   pip: name=python-catcher version=0.1.3


### PR DESCRIPTION
Install a new version of ajenti with patches to recognize OLPC platform and to improve performance loading static resources.

See patches in https://github.com/migonzalvar/ajenti/compare/0.99.34...0.99.34-patched3.

Issue https://sugardextrose.org/issues/4771
